### PR TITLE
Changing codebase to @Observable instead of @ObservableObject

### DIFF
--- a/Vineyard/Vineyard/DashboardViewModel.swift
+++ b/Vineyard/Vineyard/DashboardViewModel.swift
@@ -7,5 +7,5 @@
 
 import SwiftUI
 
-class DashboardViewModel: ObservableObject {
+@Observable class DashboardViewModel {
 }

--- a/Vineyard/Vineyard/GroupsListView.swift
+++ b/Vineyard/Vineyard/GroupsListView.swift
@@ -52,7 +52,7 @@ struct GroupsListView: View {
                     }
                 }
             }.sheet(isPresented: $isPresentingAddGroup) {
-                AddGroupView(isPresented: $isPresentingAddGroup, viewModel: viewModel)
+                AddGroupView(isPresented: $isPresentingAddGroup, viewModel: $viewModel)
             }
             
             
@@ -89,7 +89,7 @@ struct GroupCardView: View {
 
 struct AddGroupView: View {
     @Binding var isPresented: Bool
-    @ObservedObject var viewModel: GroupsListViewModel
+    @Binding var viewModel: GroupsListViewModel
     
     @State private var groupName: String = ""
     @State private var groupDescription: String = ""

--- a/Vineyard/Vineyard/GroupsListViewModel.swift
+++ b/Vineyard/Vineyard/GroupsListViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 @Observable
-class GroupsListViewModel: ObservableObject {
+class GroupsListViewModel {
     var user: Person = Person.samples[0]
     
     init() {}

--- a/Vineyard/Vineyard/ProfileViewModel.swift
+++ b/Vineyard/Vineyard/ProfileViewModel.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-class ProfileViewModel: ObservableObject {
+@Observable class ProfileViewModel {
     var user: Person = Person.samples[1]
     
     init() {}

--- a/Vineyard/Vineyard/TodoViewModel.swift
+++ b/Vineyard/Vineyard/TodoViewModel.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-class TodoViewModel: ObservableObject {
+@Observable class TodoViewModel {
     var user: Person = Person.samples[0]
     init() {}
 }

--- a/Vineyard/Vineyard/VineyardApp.swift
+++ b/Vineyard/Vineyard/VineyardApp.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 @main
 struct VineyardApp: App {
-    @ObservedObject private var viewModel = GroupsListViewModel()
+    @State private var viewModel = GroupsListViewModel()
     var body: some Scene {
         WindowGroup {
             HomeView().environment(viewModel)


### PR DESCRIPTION
# Changing codebase to @Observable instead of @ObservableObject

## Description

Removes @Observable objects to @Observable for classes. 
fixes issue #38 


