### PR TITLE
Redesign add goal view

### DIFF
--- a/Vineyard/Vineyard.xcodeproj/project.pbxproj
+++ b/Vineyard/Vineyard.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		B40B894E2C936DE0006B1771 /* ResolutionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40B894D2C936DE0006B1771 /* ResolutionView.swift */; };
 		B43CD6BD2CB5F23A0079CCBF /* CreateGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43CD6BC2CB5F23A0079CCBF /* CreateGroupView.swift */; };
 		B43CD6C52CB608200079CCBF /* CreateGoalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43CD6C42CB608200079CCBF /* CreateGoalView.swift */; };
+		B7F2BDE22CE3496E006D3E7C /* ResolutionEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F2BDE12CE3495D006D3E7C /* ResolutionEditor.swift */; };
 		BB40EDF62C991C8A006BA1E3 /* Group.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB40EDF52C991C8A006BA1E3 /* Group.swift */; };
 		BB40EDF82C991C93006BA1E3 /* Person.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB40EDF72C991C93006BA1E3 /* Person.swift */; };
 		BB40EDFA2C991C9D006BA1E3 /* Resolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB40EDF92C991C9D006BA1E3 /* Resolution.swift */; };
@@ -86,6 +87,7 @@
 		B40B894D2C936DE0006B1771 /* ResolutionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolutionView.swift; sourceTree = "<group>"; };
 		B43CD6BC2CB5F23A0079CCBF /* CreateGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateGroupView.swift; sourceTree = "<group>"; };
 		B43CD6C42CB608200079CCBF /* CreateGoalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateGoalView.swift; sourceTree = "<group>"; };
+		B7F2BDE12CE3495D006D3E7C /* ResolutionEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolutionEditor.swift; sourceTree = "<group>"; };
 		BB40EDF52C991C8A006BA1E3 /* Group.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Group.swift; sourceTree = "<group>"; };
 		BB40EDF72C991C93006BA1E3 /* Person.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Person.swift; sourceTree = "<group>"; };
 		BB40EDF92C991C9D006BA1E3 /* Resolution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resolution.swift; sourceTree = "<group>"; };
@@ -314,6 +316,7 @@
 		BB40EDFD2C991DC3006BA1E3 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				B7F2BDE12CE3495D006D3E7C /* ResolutionEditor.swift */,
 				B40B894D2C936DE0006B1771 /* ResolutionView.swift */,
 				951CF8EF2CC5C0650016B06A /* GroupListView.swift */,
 				F0D913612CACB8A100E7CD81 /* GroupView.swift */,
@@ -523,6 +526,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B7F2BDE22CE3496E006D3E7C /* ResolutionEditor.swift in Sources */,
 				F05361C82CAF1462009DE1E3 /* TodoViewModel.swift in Sources */,
 				192EBFE22C90F62E00AF8528 /* HomeView.swift in Sources */,
 				B43CD6C52CB608200079CCBF /* CreateGoalView.swift in Sources */,

--- a/Vineyard/Vineyard/CreateGoalView.swift
+++ b/Vineyard/Vineyard/CreateGoalView.swift
@@ -9,305 +9,111 @@ import SwiftUI
 
 struct CreateGoalView: View {
     @Environment(GroupsListViewModel.self) private var viewModel
-    
-    
+    @Environment(\.dismiss) var dismiss
+
     @Binding var indexOfGoal: Int
     @Binding var goals: [Resolution]
     @Binding var editMode: Bool
-    
-    @State var goalName: String = "" // the name of the goal
-    @State var description: String = "" // the description of the goal
-    @State var quantity: String = "0"
-    
-    @State var selectedDifficulty: DifficultyLevel = .easy
-    @State var selectedFrequency: FrequencyType = .daily
-    @State var selectedFrequencyText: String = ""
-    @State var freqQuantity: Int = 0
-    
-    
-    
-    @Environment(\.dismiss) var dismiss
-    @State private var words: [String] = []
-    @State private var wordPositions: [CGFloat] = []
-    @State private var dragPosition: CGPoint = .zero
-    @State private var initialDragPosition: CGPoint = .zero
-    @State private var isInserted = false
-    
-    
-    @State private var snapIndex: Int?
-    @State private var indexInserted: Int?
-    @State var isQuantityTask: Bool = false
-    
+
+    @State private var resolutionResult = ResolutionEditorResult()
+    @State private var hasQuantity: Bool = false
+
     var body: some View {
-        
-        
         @Bindable var viewModel = viewModel
-        VStack {
-            
-            Text(editMode ? "Edit Goal" : "Create Goal").font(.largeTitle).bold()
-            
-            Text("Resolution")
-                .frame(maxWidth: .infinity, alignment: .leading)
-            
-            TextField("Resolution Name:", text: $goalName)
-                .textFieldStyle(RoundedBorderTextFieldStyle())
-                .onChange(of: goalName) {
-                    words = goalName.split(separator: " ").map { String($0) }
-                    wordPositions = [CGFloat](repeating: 0, count: words.count)
-                    
-                    
-                }
-            
-                
-        
-                HStack(spacing:4) {
-                    ForEach(Array(words.enumerated()), id: \.element) { index, word in
-                        
-                                Text(word)
-                                .fontWeight(.semibold)
-                                    .background(
-                                        GeometryReader { geometry in
-                                            Color.clear
-                                                .onChange(of: goalName) {
-                                                    if index < words.count {
-                                                        wordPositions[index] = geometry.frame(in: .global).midX
-                                                    }
-                                                    
-                                            }
-                                                .onChange(of: snapIndex) {
-                                                    if index < words.count {
-                                                        wordPositions[index] = geometry.frame(in: .global).midX
-                                                    }
-                                                    
-                                                }
-                                                
-                                        })
-                                    
-                                snapIndex == index + 1 ? Rectangle()
-                                    .fill(Color.purple.opacity(0.3))
-                                    .frame(width: 4, height: 10) : nil
-                            if isInserted && indexInserted == index+1 {
-                                HStack {
-                                    Text("Quantity")
-                                        .bold()
-                                        .overlay {
-                                            LinearGradient(
-                                                colors: [.red, .blue, .green, .yellow],
-                                                startPoint: .leading,
-                                                endPoint: .trailing
-                                            )
-                                            .mask(
-                                                Text("Quantity")
-                                                    .bold()
-                                            )
-                                        }
-                                        .padding(.vertical, 8)
-                                        .padding(.leading, 8)
-                                    Image(systemName: "xmark")
-                                        .bold()
-                                        .font(.system(size: 10))
-                                        .padding(.trailing, 8)
-                                }
-                                    .background {
-                                        RoundedRectangle(cornerRadius: 20)
-                                            .foregroundStyle(.thinMaterial)
-                                    }
-                                    .onTapGesture {
-                                        isInserted = false
-                                        snapIndex = nil
-                                        indexInserted = nil
-                                        dragPosition = initialDragPosition
-                                    }
 
-                                
-                                    
-                                
-                            }
-                            
-                        
+        NavigationStack {
+            ResolutionEditor(
+                result: $resolutionResult,
+                hasQuantity: $hasQuantity
+            )
+            .navigationTitle("\(editMode ? "Edit" : "Create") Goal")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        submitGoalCreationForm()
                     }
                 }
-                .frame(height: 40)
-                
-            Spacer()
-                .frame(height: 30)
-                // Draggable word
-            Text("Drag me: ")
-                .opacity(isQuantityTask && !isInserted ? 1 : 0)
-                .background {
-                    GeometryReader { geometry in
-                        Color.clear.onAppear {
-                            initialDragPosition = .init(x: geometry.frame(in: .local).maxX + 50, y: geometry.frame(in: .local).midY - 32)
-                            print(initialDragPosition)
-                            dragPosition = initialDragPosition
-                        }
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                    Text("Quantity")
-                        .bold()
-                        .padding(8)
-                        .overlay {
-                            LinearGradient(
-                                colors: [.red, .blue, .green, .yellow],
-                                startPoint: .leading,
-                                endPoint: .trailing
-                            )
-                            .mask(
-                                Text("Quantity")
-                                    .bold()
-                            )
-                        }
-                        .background {
-                            RoundedRectangle(cornerRadius: 20)
-                                .foregroundStyle(.thinMaterial)
-                        }
-                        .position(x: dragPosition.x, y: dragPosition.y)
-                        .gesture(
-                            DragGesture()
-                                .onChanged { value in
-                                    dragPosition = value.location
-                                    if let (index, _) = wordPositions.enumerated()
-                                        .min(by: { abs($0.1 - value.location.x) < abs($1.1 - value.location.x) }) {
-                                        snapIndex = index + 1
-                                    }
-                                }
-                                .onEnded { value in
-                                    
-                                    if let snapIndex = snapIndex {
-                                        isInserted = true
-                                        indexInserted = snapIndex
-                                        self.snapIndex = nil
-                                    }
-                                }
-                        )
-                        
-                        .opacity(isQuantityTask && !isInserted ? 1 : 0)
-                        .frame(maxHeight: 40)
-                
-            
 
-            
-
-            
-            Text("Description (Optional)")
-                .frame(maxWidth: .infinity, alignment: .leading)
-            
-            TextField("Description:", text: $description)
-                .textFieldStyle(RoundedBorderTextFieldStyle())
-            Toggle("Quantity task", isOn: $isQuantityTask)
-                .onChange(of: isQuantityTask) {
-                    isInserted = false
-                    snapIndex = nil
-                    indexInserted = nil
-                    dragPosition = initialDragPosition
-                    quantity = ""
-                }
-                .padding()
-            if isQuantityTask {
-                Text("Quantity")
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                
-                TextField("2", text: $quantity).keyboardType(.numberPad)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-            }
-            
-            
-            List {
-                Picker ("Difficulty", selection: $selectedDifficulty) {
-                    Text("Easy").tag(DifficultyLevel.easy).foregroundColor(.gray)
-                    Text("Medium").tag(DifficultyLevel.medium).foregroundColor(.gray)
-                    Text("Hard").tag(DifficultyLevel.hard).foregroundColor(.gray)
-                }
-                
-                Picker ("Frequency", selection: $selectedFrequency) {
-                    Text("Daily").tag(FrequencyType.daily)
-                    Text("Weekly").tag(FrequencyType.weekly)
-                    Text("Monthly").tag(FrequencyType.monthly)
-                }
-                
-                HStack {
-                    Stepper(value: $freqQuantity, in: 0...1000) {
-                        Text("\(selectedFrequency.rawValue) count")
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
                     }
-                    Text("\(freqQuantity)")
                 }
             }
-            .frame(maxWidth: .infinity)
-            .background(.orange)
-            .listStyle(InsetListStyle())
-            
-            Button {
-                submitGoalCreationForm()
-            } label: {
-                Text(editMode ? "Update" : "Create")
-                    .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(Color(UIColor.lightGray))
-                    .foregroundColor(.black)
-                    .cornerRadius(8)
-                    .padding([.leading, .trailing])
-            }.alert(item: $viewModel.goalCreationErrorMessage) { message in
+            .onAppear {
+                if editMode {
+                    populateFormFields()
+                }
+            }
+            .alert(item: $viewModel.goalCreationErrorMessage) { message in
                 Alert(
                     title: Text("Form Error"),
                     message: Text(message.message),
                     dismissButton: .default(Text("OK"))
                 )
             }
+            .ignoresSafeArea(.keyboard)
         }
-        .onAppear {
-            if editMode {
-                populateFormFields()
-            }
-        }
-        .padding()
-        .toolbar(content: {
-            ToolbarItem(placement: .principal) {
-                
-            }
-        })
     }
-    
+
     func populateFormFields() {
-        goalName = goals[indexOfGoal].title // the name of the goal
-        description = goals[indexOfGoal].description // the name of the goal
-        quantity = String(goals[indexOfGoal].quantity ?? 0)
-        
-        selectedDifficulty = goals[indexOfGoal].diffLevel.difficultyLevel
-        selectedFrequency = goals[indexOfGoal].frequency.frequencyType
-        selectedFrequencyText = goals[indexOfGoal].frequency.frequencyType.rawValue
-        freqQuantity = 0
+        resolutionResult.resolutionTitle = goals[indexOfGoal].title // the name of the goal
+        resolutionResult.extractedQuantity = goals[indexOfGoal].quantity
+        hasQuantity = goals[indexOfGoal].quantity != nil
+
+        resolutionResult.difficulty = goals[indexOfGoal].diffLevel.difficultyLevel
+        resolutionResult.frequencyType = goals[indexOfGoal].frequency.frequencyType
+        resolutionResult.frequencyQuantity = goals[indexOfGoal].frequency.count
     }
     
     func submitGoalCreationForm() {
         do {
-            try viewModel.validateGoalCreationForm(action: goalName, quantity: quantity, isQuantityTask: isQuantityTask, isInserted: isInserted)
+            try viewModel
+                .validateGoalCreationForm(
+                    action: resolutionResult.resolutionTitle,
+                    quantity: resolutionResult.extractedQuantity,
+                    isQuantityTask: /*resolutionResult.hasQuantity*/ resolutionResult.extractedQuantity != nil
+                )
 
-            if let index = indexInserted {
-                words.insert("qtt_position", at: index)
-
-            }
-            goalName = words.joined(separator: " ")
             if editMode {
-                goals[indexOfGoal] = Resolution(id: UUID().uuidString, title: goalName, description: description, quantity: Int(quantity), frequency: Frequency(frequencyType: selectedFrequency, count: freqQuantity), diffLevel: Difficulty(difficultyLevel: selectedDifficulty, score: 10))
+                goals[indexOfGoal] = Resolution(
+                    id: UUID().uuidString,
+                    title: resolutionResult.resolutionTitle,
+                    description: /*description*/ "",
+                    quantity: resolutionResult.extractedQuantity,
+                    frequency: Frequency(
+                        frequencyType: resolutionResult.frequencyType,
+                        count: resolutionResult.frequencyQuantity
+                    ),
+                    diffLevel: Difficulty(
+                        difficultyLevel: resolutionResult.difficulty,
+                        score: 10
+                    )
+                )
             } else {
-                goals.append(Resolution(id: UUID().uuidString, title: goalName, description: description, quantity: Int(quantity), frequency: Frequency(frequencyType: selectedFrequency, count: freqQuantity), diffLevel: Difficulty(difficultyLevel: selectedDifficulty, score: 10)))
+                goals
+                    .append(
+                        Resolution(
+                            id: UUID().uuidString,
+                            title: resolutionResult.resolutionTitle,
+                            description: /*description*/ "",
+                            quantity: resolutionResult.extractedQuantity,
+                            frequency: Frequency(
+                                frequencyType: resolutionResult.frequencyType,
+                                count: resolutionResult.frequencyQuantity
+                            ),
+                            diffLevel: Difficulty(
+                                difficultyLevel: resolutionResult.difficulty,
+                                score: 10
+                            )
+                        )
+                    )
             }
-            
-            
-                  
-            goalName = "" // the name of the goal
-            description = "" // the description of the goal
-            quantity = ""
-            isQuantityTask = false
-            isInserted = false
-            snapIndex = nil
-            indexInserted = nil
-            words = []
-            wordPositions = []
-            dragPosition = initialDragPosition
-            selectedDifficulty = .medium
-            selectedFrequency = .daily
+
+            resolutionResult.resolutionTitle = "" // the name of the goal
+            resolutionResult.extractedQuantity = nil
+            resolutionResult.difficulty = .medium
+            resolutionResult.frequencyType = .daily
             editMode = false
             viewModel.isPresentingCreateGoalView = false
             dismiss()

--- a/Vineyard/Vineyard/CreateGroupView.swift
+++ b/Vineyard/Vineyard/CreateGroupView.swift
@@ -127,7 +127,7 @@ struct GoalsListView: View {
             }.padding()
             List {
                 ForEach(goals) { subGoal in
-                    Text(subGoal.title.replacingOccurrences(of: "qtt_position", with: "___")).contextMenu {
+                    Text(subGoal.finalTitle()).contextMenu {
                         Button {
                             // open the create goal view and populate the fields with current goal details
                             if let index = goals.firstIndex(where: { $0.id == subGoal.id }) {

--- a/Vineyard/Vineyard/GroupView.swift
+++ b/Vineyard/Vineyard/GroupView.swift
@@ -147,7 +147,7 @@ struct GroupView: View {
                                 Circle()
                                     .foregroundStyle(resolution.diffLevel.difficultyLevel == DifficultyLevel.easy ? .green : (resolution.diffLevel.difficultyLevel == DifficultyLevel.medium ? .yellow : .red))
                                     .frame(width: 10, height: 10)
-                                Text(resolution.title.replacingOccurrences(of: "qtt_position", with: "___"))
+                                Text(resolution.finalTitle())
                             }
                         }
                         

--- a/Vineyard/Vineyard/GroupsListViewModel.swift
+++ b/Vineyard/Vineyard/GroupsListViewModel.swift
@@ -96,13 +96,11 @@ class GroupsListViewModel {
         return true
     }
     
-    func validateGoalCreationForm(action: String, quantity: String, isQuantityTask: Bool, isInserted: Bool) throws {
+    func validateGoalCreationForm(action: String, quantity: Int?, isQuantityTask: Bool) throws {
         if action.isEmpty {
             throw ValidationError("Action can not be empty")
-        } else if isQuantityTask && quantity == "" {
+        } else if isQuantityTask && quantity == nil {
             throw ValidationError("Need to specify quantity for quantity task")
-        } else if isQuantityTask && !isInserted {
-            throw ValidationError("Need to insert quantity for quantity task")
         }
         return
     }

--- a/Vineyard/Vineyard/Resolution.swift
+++ b/Vineyard/Vineyard/Resolution.swift
@@ -13,10 +13,10 @@ struct Frequency: Codable {
     var count: Int
 }
 
-enum FrequencyType: String, Codable {
-    case daily = "Daily"
-    case weekly = "Weekly"
-    case monthly = "Monthly"
+enum FrequencyType: String, Codable, CaseIterable {
+    case daily = "day"
+    case weekly = "week"
+    case monthly = "month"
 }
 
 struct Difficulty: Codable {
@@ -24,11 +24,11 @@ struct Difficulty: Codable {
     var score: Int
 }
 
-enum DifficultyLevel: Codable {
-    case easy
-    case medium
-    case hard
-}   
+enum DifficultyLevel: String, Codable, CaseIterable {
+    case easy = "Easy"
+    case medium = "Medium"
+    case hard = "Hard"
+}
 
 struct Resolution: Identifiable, Codable {
     @DocumentID var id: String?
@@ -64,5 +64,17 @@ struct Resolution: Identifiable, Codable {
         )
         
         return [resolution1, resolution2]
+    }
+
+    func finalTitle() -> String {
+        let resolutionResult = ResolutionEditorResult(
+            resolutionTitle: title,
+            frequencyType: frequency.frequencyType,
+            frequencyQuantity: frequency.count,
+            extractedQuantity: quantity,
+            difficulty: diffLevel.difficultyLevel
+        )
+
+        return resolutionResult.finalResolutionTitle
     }
 }

--- a/Vineyard/Vineyard/ResolutionEditor.swift
+++ b/Vineyard/Vineyard/ResolutionEditor.swift
@@ -30,7 +30,7 @@ struct ResolutionEditorResult: Equatable {
 
     var attributedText: AttributedString {
         try! .init(
-            markdown: "I want to [\(resolutionTitle)](\(EditField.resolutionTitle.rawValue)) \(frequencyText) a [\(frequencyType.rawValue)](\(EditField.frequencyType.rawValue))."
+            markdown: "I want to [\(resolutionTitle)](\(EditField.resolutionTitle.rawValue)) \(frequencyText) a [\(frequencyType.rawValue)](\(EditField.frequencyType.rawValue))"
             )
     }
 
@@ -54,7 +54,7 @@ struct ResolutionEditor: View {
     var body: some View {
         VStack {
             TextViewWrapper(
-                text: result.attributedText,
+                text: result.attributedText + ".",
                 hasQuantity: hasQuantity,
                 quantityRange: quantityRange
             ) { url in
@@ -131,6 +131,7 @@ struct ResolutionEditor: View {
                     // Input Section
                     VStack(spacing: 16) {
                         TextField("Resolution Title", text: $result.resolutionTitle)
+                            .textInputAutocapitalization(.never)
                             .padding(12)
                             .background(Color(.systemGray6))
                             .cornerRadius(12)
@@ -149,6 +150,7 @@ struct ResolutionEditor: View {
 
                             Toggle("", isOn: $hasQuantity)
                                  .toggleStyle(SwitchToggleStyle(tint: .blue))
+                                 .disabled(quantityRange == nil)
                         }
 
                         Button("Done") { changeResolutionTitle.toggle() }
@@ -189,9 +191,7 @@ struct ResolutionEditor: View {
             if !new { currentlyEditingField = nil }
         }
         .onChange(of: result.resolutionTitle) { oldValue, newValue in
-            if hasQuantity {
-                getQuantity()
-            }
+            getQuantity()
         }
         .onChange(of: hasQuantity) { oldValue, newValue in
             if newValue {
@@ -211,11 +211,16 @@ struct ResolutionEditor: View {
             if let match = regex.firstMatch(in: string, range: range) {
                 let matchRange = match.range
                 if let number = Int(string[Range(matchRange, in: string)!]) {
-                    result.extractedQuantity = number
+                    if hasQuantity {
+                        result.extractedQuantity = number
+                    }
                     quantityRange = matchRange
                 }
             } else {
-                result.extractedQuantity = nil
+                if hasQuantity {
+                    result.extractedQuantity = nil
+                    hasQuantity = false
+                }
                 quantityRange = nil
             }
         }

--- a/Vineyard/Vineyard/ResolutionEditor.swift
+++ b/Vineyard/Vineyard/ResolutionEditor.swift
@@ -1,0 +1,374 @@
+//
+//  ResolutionEditor.swift
+//  Vineyard
+//
+//  Created by Rahul on 11/12/24.
+//
+
+import SwiftUI
+
+fileprivate enum EditField: String, CaseIterable {
+    case resolutionTitle = "Resolution"
+    case frequencyType = "FrequencyType"
+    case frequencyQuantity = "Frequency"
+}
+
+struct ResolutionEditorResult: Equatable {
+    var resolutionTitle = "run"
+    var frequencyType: FrequencyType = .daily
+    var frequencyQuantity: Int = 1
+    var extractedQuantity: Int?
+    var difficulty: DifficultyLevel = .medium
+
+    private var frequencyText: String {
+        if frequencyQuantity == 1 {
+            return "[\(frequencyQuantity == 1 ? "once" : "\(frequencyQuantity) times")](\(EditField.frequencyQuantity.rawValue))"
+        } else {
+            return "[\(frequencyQuantity)](\(EditField.frequencyQuantity.rawValue)) times"
+        }
+    }
+
+    var attributedText: AttributedString {
+        try! .init(
+            markdown: "I want to [\(resolutionTitle)](\(EditField.resolutionTitle.rawValue)) \(frequencyText) a [\(frequencyType.rawValue)](\(EditField.frequencyType.rawValue))."
+            )
+    }
+
+    var finalResolutionTitle: String {
+        NSAttributedString(attributedText).string
+    }
+}
+
+struct ResolutionEditor: View {
+    @Binding var result: ResolutionEditorResult
+    @State private var isPresented: Bool = false
+    @State private var changeResolutionTitle: Bool = false
+    @State private var currentlyEditingField: EditField? = EditField.resolutionTitle
+
+    @Binding var hasQuantity: Bool
+    @State private var quantityRange: NSRange?
+
+    @State private var height: CGFloat?
+    let minHeight: CGFloat = 150
+
+    var body: some View {
+        VStack {
+            TextViewWrapper(
+                text: result.attributedText,
+                hasQuantity: hasQuantity,
+                quantityRange: quantityRange
+            ) { url in
+                switch url.absoluteString {
+                case EditField.frequencyType.rawValue:
+                    return FrequencyType.allCases.map { type in
+                        MenuAction(
+                            title: type.rawValue,
+                            image: nil
+                        ) {
+                            result.frequencyType = type
+                        }
+                    }
+                default:
+                    return [
+                        MenuAction(
+                            title: "Edit \(url.absoluteString)",
+                            image: .init(systemName: "pencil")
+                        ) {
+                            currentlyEditingField = EditField(
+                                rawValue: url.absoluteString
+                            )
+                            if url.absoluteString == EditField.resolutionTitle.rawValue {
+                                changeResolutionTitle = true
+                            } else {
+                                isPresented = true
+                            }
+                        }
+                    ]
+                }
+            } textDidChange: {
+                self.height = max($0.contentSize.height, minHeight)
+            }
+            .frame(height: height ?? minHeight)
+            .padding()
+
+            Menu {
+                ForEach(DifficultyLevel.allCases, id: \.self) { diff in
+                    Button {
+                        result.difficulty = diff
+                    } label: {
+                        HStack {
+                            Text(diff.rawValue).tag(diff)
+                            Spacer()
+                            if diff == result.difficulty {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            } label: {
+                difficultyPickerLabel
+            }
+        }
+        .popover(
+            isPresented: $changeResolutionTitle,
+            attachmentAnchor: .point(.top),
+            arrowEdge: .bottom
+        ) {
+            VStack(spacing: 24) {
+                    // Title Section with decorative line
+                    VStack(spacing: 8) {
+                        Text("Edit Resolution")
+                            .font(.title2)
+                            .fontWeight(.semibold)
+                            .foregroundColor(.primary)
+
+                        Rectangle()
+                            .fill(Color.blue)
+                            .frame(width: 48, height: 4)
+                            .cornerRadius(2)
+                    }
+
+                    // Input Section
+                    VStack(spacing: 16) {
+                        TextField("Resolution Title", text: $result.resolutionTitle)
+                            .padding(12)
+                            .background(Color(.systemGray6))
+                            .cornerRadius(12)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 12)
+                                    .stroke(Color.blue.opacity(0.2), lineWidth: 1)
+                            )
+
+                        // Toggle with better styling
+                        HStack {
+                            Text("Quantity")
+                                .font(.headline)
+                                .foregroundColor(.primary)
+
+                            Spacer()
+
+                            Toggle("", isOn: $hasQuantity)
+                                 .toggleStyle(SwitchToggleStyle(tint: .blue))
+                        }
+
+                        Button("Done") { changeResolutionTitle.toggle() }
+                            .buttonStyle(.borderedProminent)
+                            .disabled(result.resolutionTitle.isEmpty)
+                    }
+                }
+                .padding(24)
+                .cornerRadius(16)
+                .frame(minWidth: 250, minHeight: 200)
+                .ignoresSafeArea(.keyboard)
+                .presentationCompactAdaptation(.popover)
+                .interactiveDismissDisabled()
+        }
+        .alert("Edit \(currentlyEditingField?.rawValue ?? "")", isPresented: $isPresented) {
+            switch currentlyEditingField {
+            case .resolutionTitle:
+                TextField("Resolution Title", text: $result.resolutionTitle)
+            case .frequencyType:
+                Picker("Frequency Type", selection: $result.frequencyType) {
+                    ForEach(FrequencyType.allCases, id: \.self) { frequencyType in
+                        Text(frequencyType.rawValue)
+                            .tag(frequencyType)
+                    }
+                }
+            case .frequencyQuantity:
+                TextField("Edit Frequency Quantity", value: $result.frequencyQuantity, format: .number)
+            default:
+                Button("OK") {  }
+            }
+        }
+        .animation(.default.speed(1.4), value: changeResolutionTitle)
+        .animation(.default.speed(1.4), value: isPresented)
+        .onAppear {
+            getQuantity()
+        }
+        .onChange(of: isPresented) { _, new in
+            if !new { currentlyEditingField = nil }
+        }
+        .onChange(of: result.resolutionTitle) { oldValue, newValue in
+            if hasQuantity {
+                getQuantity()
+            }
+        }
+        .onChange(of: hasQuantity) { oldValue, newValue in
+            if newValue {
+                getQuantity()
+            } else {
+                result.extractedQuantity = nil
+            }
+        }
+    }
+
+    func getQuantity() {
+        let string = result.resolutionTitle
+        let pattern = "\\d+" // Match one or more digits
+
+        if let regex = try? NSRegularExpression(pattern: pattern) {
+            let range = NSRange(string.startIndex..., in: string)
+            if let match = regex.firstMatch(in: string, range: range) {
+                let matchRange = match.range
+                if let number = Int(string[Range(matchRange, in: string)!]) {
+                    result.extractedQuantity = number
+                    quantityRange = matchRange
+                }
+            } else {
+                result.extractedQuantity = nil
+                quantityRange = nil
+            }
+        }
+    }
+
+    private var difficultyPickerLabel: some View {
+        HStack {
+            Text("Difficulty")
+                .bold()
+                .foregroundStyle(difficultyColor)
+
+            Text(result.difficulty.rawValue)
+                .foregroundStyle(difficultyColor)
+        }
+        .padding()
+        .background(difficultyColor.opacity(0.2), in: .capsule)
+        .frame(width: 250)
+    }
+
+    private var difficultyColor: Color {
+        switch result.difficulty {
+        case .easy:
+                .green
+        case .medium:
+                .orange
+        case .hard:
+                .red
+        }
+    }
+}
+
+fileprivate struct MenuAction {
+    let title: String
+    let image: UIImage?
+    let action: () -> Void
+}
+
+fileprivate struct TextViewWrapper: UIViewRepresentable {
+    let text: AttributedString
+    let hasQuantity: Bool
+    let quantityRange: NSRange?
+    let actionsForURL: ((URL) -> [MenuAction])
+    let textDidChange: (UITextView) -> Void
+
+    func makeUIView(context: Context) -> UITextView {
+        let textView = UITextView()
+        textView.isEditable = false
+        textView.delegate = context.coordinator
+        textView.linkTextAttributes = [:]
+        return textView
+    }
+
+    func updateUIView(_ uiView: UITextView, context: Context) {
+        let attributedText = NSMutableAttributedString(attributedString: NSAttributedString(text))
+
+        // Set font size and bold style for the entire text
+        let font = UIFont.boldSystemFont(ofSize: 50)
+        attributedText.addAttribute(.font, value: font, range: NSRange(location: 0, length: attributedText.length))
+
+        // Center align the text
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = .center
+        attributedText.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: attributedText.length))
+
+        // Customize link appearance to be gray and underlined
+        attributedText.enumerateAttribute(.link, in: NSRange(location: 0, length: attributedText.length)) { value, range, _ in
+            if value != nil {
+                attributedText.addAttribute(.foregroundColor, value: UIColor.gray, range: range)
+                attributedText.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: range)
+            }
+        }
+
+        // Highlight quantity if hasQuantity is true and we have a valid range
+        if hasQuantity, let quantityRange = quantityRange {
+            // Find the range of the resolutionTitle link
+            attributedText.enumerateAttribute(.link, in: NSRange(location: 0, length: attributedText.length)) { value, range, _ in
+                if let url = value as? URL, url.absoluteString == EditField.resolutionTitle.rawValue {
+                    // Calculate the offset within the link text
+                    let highlightRange = NSRange(location: range.location + quantityRange.location, length: quantityRange.length)
+                    attributedText.addAttribute(.foregroundColor, value: UIColor.systemBlue, range: highlightRange)
+                    // attributedText.addAttribute(.backgroundColor, value: UIColor.systemBlue.withAlphaComponent(0.2), range: highlightRange)
+                }
+            }
+        }
+
+        uiView.attributedText = attributedText
+        context.coordinator.actionsForURL = actionsForURL
+
+        DispatchQueue.main.async {
+            self.textDidChange(uiView)
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        .init(actionsForURL: actionsForURL, textDidChange: textDidChange)
+    }
+
+    class Coordinator: NSObject, UITextViewDelegate, UITextDragDelegate {
+        var actionsForURL: ((URL) -> [MenuAction])
+        let textDidChange: (UITextView) -> Void
+
+        init(
+            actionsForURL: @escaping (URL) -> [MenuAction],
+            textDidChange: @escaping (UITextView) -> Void
+        ) {
+            self.actionsForURL = actionsForURL
+            self.textDidChange = textDidChange
+        }
+
+        func textView(_ textView: UITextView, primaryActionFor textItem: UITextItem, defaultAction: UIAction) -> UIAction? {
+            guard case let .link(url) = textItem.content else { return nil }
+
+            if url.absoluteString ==
+                EditField.frequencyType.rawValue {
+                return nil
+            }
+
+            return actionsForURL(url).map { action in
+                UIAction(
+                    title: action.title,
+                    image: action.image
+                ) { _ in
+                    action.action()
+                }
+            }.first
+        }
+
+        func textView(_ textView: UITextView, menuConfigurationFor textItem: UITextItem, defaultMenu: UIMenu) -> UITextItem.MenuConfiguration? {
+            guard case let .link(url) = textItem.content else { return nil }
+            return .init(
+                preview: nil,
+                menu: UIMenu(
+                    children: actionsForURL(url).map { action in
+                        UIAction(
+                            title: action.title,
+                            image: action.image
+                        ) { _ in
+                            action.action()
+                        }
+                    })
+            )
+        }
+
+        func textViewDidChange(_ textView: UITextView) {
+            self.textDidChange(textView)
+        }
+    }
+}
+
+#Preview {
+    @Previewable @State var res = ResolutionEditorResult()
+    ResolutionEditor(
+        result: $res,
+        hasQuantity: .constant(true)
+    )
+}


### PR DESCRIPTION
# Redesign add goal view

## Description

- Redesign the add goal view using a custom view that allows you to tap on specific details to edit in-line.
- `description` is no longer used for a resolution object (stays "")

## Screenshot/Recording (if applicable)

<img src="https://github.com/user-attachments/assets/42f2cff4-8cf2-40ae-990c-0fd320ff1297" width="200pt">

